### PR TITLE
Upgrade to support Elixir 1.12

### DIFF
--- a/lib/exunit_summarizer.ex
+++ b/lib/exunit_summarizer.ex
@@ -8,6 +8,14 @@ defmodule ExunitSummarizer do
 
   @impl true
   def handle_cast({:suite_finished, _run_us, _load_us}, test_cases) do
+    # Elixir <= 1.11
+    write_report(test_cases)
+
+    {:noreply, test_cases}
+  end
+
+  def handle_cast({:suite_finished, _times_us}, test_cases) do
+    # Elixir >= 1.12
     write_report(test_cases)
 
     {:noreply, test_cases}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExunitSummarizer.MixProject do
     [
       app: :exunit_summarizer,
       version: "0.1.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.10.0 or ~> 1.11.0 or ~>1.12.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_options: [warnings_as_errors: true]


### PR DESCRIPTION
Elixir 1.12 changed the `:suite_finished` event from a 3-tuple to a 2-tuple.

1.12 docs: https://hexdocs.pm/ex_unit/1.12.1/ExUnit.Formatter.html
1.11 docs: https://hexdocs.pm/ex_unit/1.11.4/ExUnit.Formatter.html

I've also stricter bounded the Elixir versions to ones we support.

It'd be good to have some Buildkite stuff setup to run the `./test.sh` script which tests the system, but I don't have time to set that up at the moment.